### PR TITLE
rows in scan are filtered using columns argument

### DIFF
--- a/happybase_mock/table.py
+++ b/happybase_mock/table.py
@@ -156,7 +156,12 @@ class Table(object):
             if not isinstance(row_start, bytes):
                 row_start = row_start.encode('utf-8')
 
-        rows = filter(lambda k: k >= row_start, self._data)
+        if columns:
+            rows = (k for k, v in self._data.items() if set(columns).intersection(v))
+        else:
+            rows = self._data.keys()
+
+        rows = filter(lambda k: k >= row_start, rows)
         if row_stop is not None:
             if not isinstance(row_stop, bytes):
                 row_stop = row_stop.encode('utf-8')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -262,6 +262,22 @@ class TestTable(BaseTestCase):
             (b'2', {b'd:count': b'2'})
         ])
 
+    def test_scan_with_multiple_columns(self):
+        self.table.put(b'1', {b'd:first': 'f1'})
+
+        self.table.put(b'2', {b'd:first': 'f2',
+                              b'd:second': 's2'})
+
+        self.table.put(b'3', {b'd:first': 'f3',
+                              b'd:second': 's3',
+                              b'd:third': 't3'})
+
+        self.assertEqual(list(self.table.scan(columns=[b'd:first', b'd:second'])), [
+            (b'1', {b'd:first': b'f1'}),
+            (b'2', {b'd:first': b'f2', b'd:second': b's2'}),
+            (b'3', {b'd:first': b'f3', b'd:second': b's3'})
+        ])
+
     def test_scan_arbitrary_binary_row_keys(self):
         common_prefix = md5(b'common_prefix').digest()
         row_key1 = b''.join([common_prefix, b'key1'])


### PR DESCRIPTION
Rows in scan method should be selected using columns argument. Data where no columns from columns argument are presented should be excluded during scan.